### PR TITLE
Add detection robot ID

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -11,6 +11,7 @@ import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 import frc.robot.config.C2025RobotFactory;
+import frc.robot.config.RobotFactory;
 import frc.robot.utility.MacAddressUtils;
 import frc.robot.utility.RobotId;
 
@@ -52,7 +53,12 @@ public class Robot extends TimedRobot {
             runtimeId = detectedId != null ? detectedId : RobotId.C2025;
         }
 
-        robotContainer = new RobotContainer(new C2025RobotFactory());
+        RobotFactory robotFactory = switch (runtimeId) {
+            case C2025 -> new C2025RobotFactory();
+            default -> new RobotFactory() {};
+        };
+
+        robotContainer = new RobotContainer(robotFactory);
 
         Epilogue.configure(config -> {
         });

--- a/src/main/java/frc/robot/utility/MacAddressUtils.java
+++ b/src/main/java/frc/robot/utility/MacAddressUtils.java
@@ -40,6 +40,7 @@ public final class MacAddressUtils {
                                 if (i != 0) {
                                     builder.append('-');
                                 }
+                                // Turn each byte of the MAC address into a 2-digit hex number
                                 builder.append(String.format("%02x", address[i]));
                             }
 

--- a/src/main/java/frc/robot/utility/MacAddressUtils.java
+++ b/src/main/java/frc/robot/utility/MacAddressUtils.java
@@ -1,0 +1,58 @@
+package frc.robot.utility;
+
+import edu.wpi.first.wpilibj.DriverStation;
+
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utilities for retrieving the MAC addresses of the current system.
+ */
+public final class MacAddressUtils {
+    private MacAddressUtils() {
+        throw new UnsupportedOperationException("MacAddressUtils is a utility class and cannot be instantiated");
+    }
+
+    /**
+     * Retrieves the MAC addresses of all the network interfaces of the current system.
+     *
+     * @return The MAC addresses of the system's network adapters.
+     */
+    public static Set<String> getMacAddresses() {
+        try {
+            return NetworkInterface.networkInterfaces()
+                    .flatMap(iface -> {
+                        try {
+                            byte[] address = iface.getHardwareAddress();
+
+                            // If the interface doesn't have a hardware address, skip it.
+                            if (address == null) {
+                                return Stream.empty();
+                            }
+
+                            // Build the MAC address string
+                            StringBuilder builder = new StringBuilder();
+                            for (int i = 0; i < address.length; i++) {
+                                if (i != 0) {
+                                    builder.append('-');
+                                }
+                                builder.append(String.format("%02x", address[i]));
+                            }
+
+                            return Stream.of(builder.toString());
+                        } catch (SocketException e) {
+                            return Stream.empty();
+                        }
+                    })
+                    .collect(Collectors.toSet());
+        } catch (SocketException e) {
+            DriverStation.reportError("Failed to retrieve MAC address", e.getStackTrace());
+
+            return Collections.emptySet();
+        }
+    }
+}

--- a/src/main/java/frc/robot/utility/RobotId.java
+++ b/src/main/java/frc/robot/utility/RobotId.java
@@ -1,0 +1,17 @@
+package frc.robot.utility;
+
+public enum RobotId {
+    SIM("00-00-00-00-00-00"),
+    C2024("00-80-2f-33-d0-1b"),
+    C2025("00-80-2f-33-d0-3f");
+
+    private final String macAddress;
+
+    RobotId(String macAddress) {
+        this.macAddress = macAddress;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+}


### PR DESCRIPTION
Adds functionality to detect robot ID. This will be used for determining which `RobotFactory` implementation to use so we can have a single code base running on multiple robots.