### PR TITLE
Subsystems must be zeroed and won't exceed their minimums or maximums

### DIFF
--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -107,33 +107,41 @@ public class Arm extends SubsystemBase {
     public boolean atTargetPositions() {
         return this.atShoulderTargetPosition() && this.atWristTargetPosition();
     }
+
     public boolean atPositions(double shoulderPosition, double wristPosition) {
         return this.shoulderAtPosition(shoulderPosition, POSITION_THRESHOLD) && this.wristAtPosition(wristPosition, POSITION_THRESHOLD);
     }
 
     public Command goToPositions(double shoulderPosition, double wristPosition) {
         return runEnd(() -> {
-                    // Shoulder
-                    targetShoulderPosition = shoulderPosition;
-                    io.setShoulderTargetPosition(shoulderPosition);
+            // Shoulder
+            targetShoulderPosition = getValidPositionShoulder(shoulderPosition);
+            io.setShoulderTargetPosition(targetShoulderPosition);
 
-                    // Wrist
-                    targetWristPosition = wristPosition;
-                    io.setWristTargetPosition(wristPosition);
-                }, this::stop
-        ).until(this::atTargetPositions);
+            // Wrist
+            targetWristPosition = getValidPositionWrist(wristPosition);
+            io.setWristTargetPosition(wristPosition);
+        }, this::stop).until(this::atTargetPositions);
     }
 
     public Command followPositions(DoubleSupplier shoulderPosition, DoubleSupplier wristPosition) {
         return runEnd(() -> {
             // Shoulder
-            targetShoulderPosition = shoulderPosition.getAsDouble();
+            targetShoulderPosition = getValidPositionShoulder(shoulderPosition.getAsDouble());
             io.setShoulderTargetPosition(targetShoulderPosition);
 
             // Wrist
-            targetWristPosition = wristPosition.getAsDouble();
+            targetWristPosition = getValidPositionWrist(wristPosition.getAsDouble());
             io.setWristTargetPosition(targetWristPosition);
         }, this::stop);
+    }
+
+    private double getValidPositionShoulder(double position) {
+        return Math.max(constants.minimumShoulderAngle, Math.min(constants.maximumShoulderAngle, position));
+    }
+
+    private double getValidPositionWrist(double position) {
+        return Math.max(constants.minimumWristAngle, Math.min(constants.maximumWristAngle, position));
     }
 
     public double getShoulderPosition() {

--- a/src/main/java/frc/robot/subsystems/arm/Arm.java
+++ b/src/main/java/frc/robot/subsystems/arm/Arm.java
@@ -182,8 +182,10 @@ public class Arm extends SubsystemBase {
     }
 
     public Command zeroWrist() {
-        return runEnd(() -> io.setWristTargetVoltage(-1.0),
-                io::stopWrist)
+        return runEnd(() -> {
+            io.setWristTargetVoltage(-1.0);
+            io.setShoulderTargetPosition(Units.degreesToRadians(90));
+        }, io::stopWrist)
                 .withDeadline(waitUntil(() -> Math.abs(inputs.currentWristVelocity) < 0.01)
                         .beforeStarting(waitSeconds(0.25))
                         .andThen(() -> {

--- a/src/main/java/frc/robot/subsystems/climber/C2025ClimberIO.java
+++ b/src/main/java/frc/robot/subsystems/climber/C2025ClimberIO.java
@@ -21,7 +21,7 @@ import frc.robot.Robot;
 
 public class C2025ClimberIO implements ClimberIO {
     // TODO: Get real values from CAD
-    private static final Climber.Constants CONSTANTS = new Climber.Constants(1.0);
+    private static final Climber.Constants CONSTANTS = new Climber.Constants(1.0, -1.0);
 
     private final TalonFX motor;
     private final CANcoder coder;

--- a/src/main/java/frc/robot/subsystems/climber/Climber.java
+++ b/src/main/java/frc/robot/subsystems/climber/Climber.java
@@ -27,7 +27,7 @@ public class Climber extends SubsystemBase {
     private final ClimberInputs inputs = new ClimberInputs();
     private final SysIdRoutine sysIdRoutine;
 
-    private boolean wristZeroed = false;
+    private boolean zeroed = false;
     private double targetPosition = 0.0;
     private double targetVoltage = 0.0;
 
@@ -85,7 +85,7 @@ public class Climber extends SubsystemBase {
     public Command goToPosition(double position) {
         return runEnd(
                 () -> {
-                    if (wristZeroed) {
+                    if (zeroed) {
                         targetPosition = getValidPosition(position);
                         io.setTargetPosition(targetPosition);
                     }
@@ -96,7 +96,7 @@ public class Climber extends SubsystemBase {
     public Command followPosition(DoubleSupplier position) {
         return runEnd(
                 () -> {
-                    if (wristZeroed) {
+                    if (zeroed) {
                         targetPosition = getValidPosition(position.getAsDouble());
                         io.setTargetPosition(targetPosition);
                     }
@@ -118,7 +118,7 @@ public class Climber extends SubsystemBase {
                         // Then reset the elevator position and set wristZeroed to true
                         .andThen(() -> {
                             io.resetPosition();
-                            wristZeroed = true;
+                            zeroed = true;
                         })
                         // Before we check if we're at the bottom hard stop, wait a little so that it doesn't think we hit it because we haven't started going yet
                         .beforeStarting(waitSeconds(WAIT_TIME)));

--- a/src/main/java/frc/robot/subsystems/climber/ClimberIO.java
+++ b/src/main/java/frc/robot/subsystems/climber/ClimberIO.java
@@ -23,7 +23,8 @@ public interface ClimberIO {
     default void stop() {
         setTargetVoltage(0.0);
     }
+
     default Climber.Constants getConstants() {
-        return new Climber.Constants(0);
+        return new Climber.Constants(0, 0);
     }
 }

--- a/src/main/java/frc/robot/subsystems/elevator/Elevator.java
+++ b/src/main/java/frc/robot/subsystems/elevator/Elevator.java
@@ -25,7 +25,6 @@ public class Elevator extends SubsystemBase {
     private final Constants constants;
     private final SysIdRoutine sysIdRoutine;
 
-
     private boolean zeroed = false;
     private double targetPosition = 0.0;
 
@@ -96,16 +95,24 @@ public class Elevator extends SubsystemBase {
 
     public Command goToPosition(double position) {
         return run(() -> {
-            io.setTargetPosition(position);
-            targetPosition = position;
+            if (zeroed) {
+                targetPosition = getValidPosition(position);
+                io.setTargetPosition(targetPosition);
+            }
         }).until(this::atTargetPosition);
     }
 
     public Command followPosition(DoubleSupplier position) {
         return runEnd(() -> {
-            targetPosition = position.getAsDouble();
-            io.setTargetPosition(targetPosition);
+            if (zeroed) {
+                targetPosition = getValidPosition(position.getAsDouble());
+                io.setTargetPosition(targetPosition);
+            }
         }, io::stop);
+    }
+
+    private double getValidPosition(double position) {
+        return Math.max(constants.minimumPosition, Math.min(constants.maximumPosition, position));
     }
 
     public Command zero() {


### PR DESCRIPTION
Made it so that the Wrist, Elevator, and Climber won't move the motors using any of the commands until they are zeroed (not including the zero command).
Also made it so that for the Wrist, Shoulder, Elevator, and Climber will not move out of their respective minimum or maximum positions. If you tell them to move outside they will just go to the closest position they can.